### PR TITLE
Removing hard-coded path to git command

### DIFF
--- a/githistorydata/main.py
+++ b/githistorydata/main.py
@@ -6,11 +6,13 @@ from githistorydata.csv import Csv
 from githistorydata.expand_commits import expand_authors, expand_lines
 from githistorydata.git import Git
 from githistorydata.rawgit import RawGit
+from githistorydata.settings import Settings
 
 
 def main( argv, out, err ):
+    settings = Settings()
     try:
-        git = Git( RawGit() )
+        git = Git( RawGit(settings["git_path"]) )
         csv = Csv(
             out,
             ( "Commit", "Date", "Author", "Added", "Removed", "File" )

--- a/githistorydata/rawgit.py
+++ b/githistorydata/rawgit.py
@@ -3,8 +3,8 @@ import subprocess
 
 
 class RawGit( object ):
-    def __init__( self ):
-        pass
+    def __init__( self, git_path="/usr/bin/git" ):
+        self._git_path = git_path
 
     def git_log_pretty_tformat_H_ai_an( self ):
         return self._run_git(
@@ -16,6 +16,6 @@ class RawGit( object ):
 
     def _run_git( self, args ):
         return subprocess.check_output(
-            ["/usr/bin/git"] + args
+            [self._git_path] + args
         ).decode( encoding="UTF-8", errors="replace" ).split( "\n" )
 

--- a/githistorydata/settings.py
+++ b/githistorydata/settings.py
@@ -1,0 +1,46 @@
+import json
+
+
+class Settings:
+    """ Asettings object that is responsible of managing a single settings file """
+
+    def __init__(self, settings_file_path="settings.json"):
+        """ Initialize a Settings object """
+        self._settings_file_path = settings_file_path
+        self._settings_dict = {}
+        self.load()
+
+    def load(self):
+        """ Load settings from file """
+        with open(self._settings_file_path) as f:
+            self._settings_dict = dict(self._settings_dict, **json.load(f))
+
+    def add(self, settings):
+        """ Add one or more extra settings to this object without persisting them.
+            settings must be a mapping object"""
+        self._settings_dict = dict(self._settings_dict, **settings)
+
+    def save(self):
+        """ Save this object to file as it is, possibly overriting un-synced changed in the file """
+        with open(self._settings_file_path, "w") as f:
+            json.dump(self._settings_dict, f)
+
+    def persist(self, settings=None):
+        """ Potentially add settings to this object, then persist all the settings in it """
+        # if new settings received, add them to this object
+        if settings:
+            self.add(settings)
+
+        # synchronize settings with file
+        self.load()
+
+        # persist all settings to file
+        self.save()
+
+    def __getitem__(self, key):
+        """ Access Settings using square brackets """
+        return self._settings_dict[key]
+
+    def __setitem__(self, key, value):
+        """ Set items using square brackets without persisting the change """
+        self._settings_dict[key] = value

--- a/legal/ZackYovel-DCO1.1.txt
+++ b/legal/ZackYovel-DCO1.1.txt
@@ -1,0 +1,25 @@
+Developer's Certificate of Origin 1.1
+
+       By making a contribution to this project, I certify that:
+
+       (a) The contribution was created in whole or in part by me and I
+           have the right to submit it under the open source license
+           indicated in the file; or
+
+       (b) The contribution is based upon previous work that, to the best
+           of my knowledge, is covered under an appropriate open source
+           license and I have the right under that license to submit that
+           work with modifications, whether created in whole or in part
+           by me, under the same open source license (unless I am
+           permitted to submit under a different license), as indicated
+           in the file; or
+
+       (c) The contribution was provided directly to me by some other
+           person who certified (a), (b) or (c) and I have not modified
+           it.
+
+       (d) I understand and agree that this project and the contribution
+           are public and that a record of the contribution (including all
+           personal information I submit with it, including my sign-off) is
+           maintained indefinitely and may be redistributed consistent with
+           this project or the open source license(s) involved.

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,3 @@
+{
+	"git_path": "/usr/bin/git"
+}

--- a/tests/test__csv.py
+++ b/tests/test__csv.py
@@ -1,0 +1,53 @@
+import unittest
+from io import StringIO
+from githistorydata.csv import Csv
+
+
+class TestCsv(unittest.TestCase):
+    def test__Headings_are_printed_quoted(self):
+        out = StringIO()
+        csv = Csv( out, ( "a", "B c" ) )
+        csv # Silence lint
+        self.assertEqual(
+            '''"a", "B c"
+''',
+            out.getvalue()
+        )
+
+
+    def test__String_lines_are_printed_in_quotes(self):
+        out = StringIO()
+        csv = Csv( out, ( "a", "b" ) )
+        csv.line( ( "x", "y" ) )
+        self.assertEqual(
+            '''"a", "b"
+"x", "y"
+''',
+            out.getvalue()
+        )
+
+
+    def test__Number_lines_are_printed_without_quotes(self):
+        out = StringIO()
+        csv = Csv( out, ( "a", "b", "c" ) )
+        csv.line( ( 2, "x", 3.5 ) )
+        self.assertEqual(
+            '''"a", "b", "c"
+2, "x", 3.5
+''',
+            out.getvalue()
+        )
+
+
+    def test__Multiple_lines_are_printed(self):
+        out = StringIO()
+        csv = Csv( out, ( "a", "b", "c" ) )
+        csv.line( ( 2, "x", 3.5 ) )
+        csv.line( ( 4, "y", 5.5 ) )
+        self.assertEqual(
+            '''"a", "b", "c"
+2, "x", 3.5
+4, "y", 5.5
+''',
+            out.getvalue()
+        )

--- a/tests/test__expand_commits.py
+++ b/tests/test__expand_commits.py
@@ -1,0 +1,143 @@
+
+from githistorydata.codeline import CodeLine
+from githistorydata.commitdetail import CommitDetail
+from githistorydata.dataline import DataLine
+from githistorydata.expand_commits import expand_authors
+from githistorydata.expand_commits import expand_detail
+from githistorydata.expand_commits import expand_lines
+from githistorydata.filechanges import FileChanges
+from githistorydata.git import Git
+from githistorydata.logline import LogLine
+
+from tests.fakegit import FakeGit
+
+import unittest
+
+
+class TestExpandCommits(unittest.TestCase):
+    def test__Normal_commits_are_not_expanded(self):
+        self.assertEqual(
+            [
+                CodeLine( "h1", "dt1", "a1", 1.0 ),
+                CodeLine( "h2", "dt2", "a2", 1.0 ),
+            ],
+            list( expand_authors(
+                [
+                    LogLine( "h1", "dt1", "a1" ),
+                    LogLine( "h2", "dt2", "a2" ),
+                ]
+            ) )
+        )
+
+
+    def test__Shared_commits_are_expanded(self):
+        self.assertEqual(
+            [
+                CodeLine( "h1", "dt1", "a1", 0.5 ),
+                CodeLine( "h1", "dt1", "a2", 0.5 ),
+            ],
+            list( expand_authors(
+                [
+                    LogLine( "h1", "dt1", "a1,a2" ),
+                ]
+            ) )
+        )
+
+
+    def test__Multiple_commits(self):
+        self.assertEqual(
+            [
+                CodeLine( "h1", "dt1", "a1", 1.0 ),
+                CodeLine( "h2", "dt2", "a1", 1.0/3 ),
+                CodeLine( "h2", "dt2", "a2", 1.0/3 ),
+                CodeLine( "h2", "dt2", "a3", 1.0/3 ),
+                CodeLine( "h4", "dt4", "a4", 1.0 ),
+            ],
+            list( expand_authors(
+                [
+                    LogLine( "h1", "dt1", "a1" ),
+                    LogLine( "h2", "dt2", "a1,a2,a3" ),
+                    LogLine( "h4", "dt4", "a4" ),
+                ]
+            ) )
+        )
+
+
+    def test__Expand_detail_for_single_author(self):
+        self.assertEqual(
+            [
+                DataLine(
+                    "myhash1",
+                    "mydate1",
+                    "Me",
+                    32,
+                    1,
+                    "foo.txt",
+                ),
+                DataLine(
+                    "myhash1",
+                    "mydate1",
+                    "Me",
+                    0,
+                    10,
+                    "bar.pl",
+                )
+            ],
+            list( expand_detail(
+                CommitDetail(
+                    "myhash1",
+                    "mydate1",
+                    "Me",
+                    [
+                        FileChanges( 32, 1,  "foo.txt" ),
+                        FileChanges( 0,  10, "bar.pl" ),
+                    ]
+                ),
+                1.0
+            ) )
+        )
+
+
+    def test__Expand_detail_with_weights_on_lines(self):
+        self.assertEqual(
+            [
+                DataLine( "h", "d", "Me", 9, 0, "foo.txt" ),
+                DataLine( "h", "d", "Me", 0, 3, "bar.pl" ),
+            ],
+            list( expand_detail(
+                CommitDetail(
+                    "h",
+                    "d",
+                    "Me",
+                    [
+                        FileChanges( 32, 1,  "foo.txt" ),
+                        FileChanges( 0,  10, "bar.pl" ),
+                    ]
+                ),
+                0.3
+            ) )
+        )
+
+
+    def Expand_lines_makes_one_line_for_each_modified_file(self):
+        git = Git( FakeGit( """2976 Andy Balaam "desc."
+10      2       f.txt
+1       0       g.txt
+""", """2976 Peter Broadbent "desc2."
+0       18      h.txt
+4       14      i.txt
+
+""") )
+        self.assertEqual(
+            [
+                DataLine( "h", "d", "a", 10, 2, "f.txt" ),
+                DataLine( "h", "d", "a",  1, 0, "g.txt" ),
+                DataLine( "j", "e", "b",  0, 9, "h.txt" ),
+                DataLine( "j", "e", "b",  2, 7, "i.txt" ),
+            ],
+            expand_lines(
+                git,
+                CodeLine( "h", "d", "a", 1.0 ),
+                CodeLine( "j", "j", "b", 0.5 ),
+            )
+        )

--- a/tests/test__git_parsing.py
+++ b/tests/test__git_parsing.py
@@ -1,0 +1,88 @@
+
+from datetime import datetime
+import dateutil.parser
+
+from githistorydata.commitdetail import CommitDetail
+from githistorydata.filechanges import FileChanges
+from githistorydata.git import Git
+from githistorydata.logline import LogLine
+
+from tests.fakegit import FakeGit
+
+import unittest
+
+
+class TestGitParsing(unittest.TestCase):
+    def test__Log_lines_are_parsed(self):
+        git = Git( FakeGit( """
+64c5da790fb7edef4f99053497075839d11bb6d8 2015-07-09 12:00:00 +0100 Alban Tsui
+2993dbf67c7e0659eba13987c98c5a03aade7099 2015-10-31 12:15:27 +0100 Lennart Tange
+c504bd352d5d9dd0ccec3cd601ac02b14f4982a8 2015-07-09 12:00:00 -0200 Alban Tsui
+""" ) )
+
+        off1 = dateutil.tz.tzoffset( "tz",    60*60 )  # +0100
+        off2 = dateutil.tz.tzoffset( "tz", -2*60*60 )  # -0200
+
+        self.assertEqual(
+            [
+                LogLine(
+                    "64c5da790fb7edef4f99053497075839d11bb6d8",
+                    datetime( 2015, 7, 9, 12, 0, 0, 0, off1 ),
+                    "Alban Tsui"
+                ),
+                LogLine(
+                    "2993dbf67c7e0659eba13987c98c5a03aade7099",
+                    datetime( 2015, 10, 31, 12, 15, 27, 0, off1 ),
+                    "Lennart Tange"
+                ),
+                LogLine(
+                    "c504bd352d5d9dd0ccec3cd601ac02b14f4982a8",
+                    datetime( 2015, 7, 9, 12, 0, 0, 0, off2 ),
+                    "Alban Tsui"
+                )
+            ],
+            git.log()
+        )
+
+
+    def test__FileChanges_to_string(self):
+        self.assertEqual( "+3 -2 foo.txt", str( FileChanges( 3, 2, "foo.txt" ) ) )
+
+
+    def test__CommitDetail_to_string(self):
+        self.assertEqual(
+            """myhash dt auth
+    +1 -0 x.cpp
+    +3 -2 y.cpp""",
+            str( CommitDetail(
+                "myhash",
+                "dt",
+                "auth",
+                [
+                    FileChanges( 1, 0, "x.cpp" ),
+                    FileChanges( 3, 2, "y.cpp" ),
+                ]
+            ) )
+        )
+
+
+    def test__Numstat_lines_are_parsed(self):
+        git = Git( FakeGit( """2993dbf Lennart Tange "More generic dnd helper."
+71      0       scripts/drag_and_drop_helper.js
+0       66      scripts/dragdrop_pin_to_assemble.js
+23      16      src/step_definitions/StepDef.java
+""" ) )
+
+        self.assertEqual(
+            str( CommitDetail(
+                "2993bdfAAAAAAAAAAAA",
+                "dt",
+                "auth",
+                [
+                    FileChanges( 71,  0, "scripts/drag_and_drop_helper.js" ),
+                    FileChanges(  0, 66, "scripts/dragdrop_pin_to_assemble.js" ),
+                    FileChanges( 23, 16, "src/step_definitions/StepDef.java" ),
+                ]
+            ) ),
+            str( git.show( "2993bdfAAAAAAAAAAAA", "dt", "auth" ) )
+        )

--- a/tests/test__settings.py
+++ b/tests/test__settings.py
@@ -1,0 +1,116 @@
+import unittest
+import json
+import os
+from githistorydata.settings import Settings
+
+""" Tests file for unittest/nose2 """
+
+TEST_SETTINGS_FILE = "test_settings.json"
+
+
+def get_test_settings():
+    return Settings(TEST_SETTINGS_FILE)
+
+
+def persist_test_settings(settings):
+    with open(TEST_SETTINGS_FILE, "w") as f:
+        json.dump(settings, f)
+
+
+def update_test_settings(settings):
+    """ Update the file 'manually' (not through the Settings API)
+    and create a new Settings object """
+    persist_test_settings(settings)
+    return get_test_settings()
+
+
+class TestSettings(unittest.TestCase):
+
+    def setUp(self):
+        settings = {}
+        persist_test_settings(settings)
+
+    def tearDown(self):
+        os.remove(TEST_SETTINGS_FILE)
+    
+    def test_ctor(self):
+        # test default ctor
+        settings = Settings()
+        self.assertEqual(settings["git_path"], "/usr/bin/git")
+
+        # test ctor with settings_file_path argument
+        settings = {"key1": "value1"}
+        settings = update_test_settings(settings)
+        self.assertEqual(settings["key1"], "value1")
+
+    def test_load(self):
+        settings1 = get_test_settings()
+        # assert 'key1' is not in the settings
+        with self.assertRaises(KeyError):
+            s = settings1["key1"]
+        # write the 'key1' setting to the test file
+        # (not using the Settings API)
+        settings2 = {"key1": "value1"}
+        persist_test_settings(settings2)
+        # perform 'load'
+        settings1.load()
+        # assert 'key1' is in settings
+        self.assertEqual(settings1["key1"], "value1")
+
+    def test_add(self):
+        settings = get_test_settings()
+        # assert 'key1' is not in the settings
+        with self.assertRaises(KeyError):
+            s = settings["key1"]
+        # add 'key1'
+        settings.add({"key1": "value1"})
+        # assert 'key1' is in settings
+        self.assertEqual(settings["key1"], "value1")
+        # assert 'key1' not persisted
+        settings = get_test_settings()
+        with self.assertRaises(KeyError):
+            s = settings["key1"]
+
+    def test_save(self):
+        settings = get_test_settings()
+        # assert 'key1' is not in the settings
+        with self.assertRaises(KeyError):
+            s = settings["key1"]
+        # add 'key1'
+        settings.add({"key1": "value1"})
+        # save settings
+        settings.save()
+        # assert 'key1' persisted
+        settings = get_test_settings()
+        self.assertEqual(settings["key1"], "value1")
+
+    def test_persist(self):
+        settings = get_test_settings()
+        # assert 'key1' is not in the settings
+        with self.assertRaises(KeyError):
+            s = settings["key1"]
+        # persist 'key1'
+        settings.persist({"key1": "value1"})
+        # assert 'key1' persisted
+        settings = get_test_settings()
+        self.assertEqual(settings["key1"], "value1")
+
+    def test___getitmem__(self):
+        # test the [] accessors
+        settings = Settings()
+        self.assertEqual(settings["git_path"], "/usr/bin/git")
+
+    def test___setitem__(self):
+        settings = get_test_settings()
+        # assert 'key1' is not in the settings
+        with self.assertRaises(KeyError):
+            s = settings["key1"]
+        # set 'key1'
+        settings["key1"] = "value1"
+        # assert 'key1' is in settings
+        self.assertEqual(settings["key1"], "value1")
+        # assert 'key1' not persisted
+        settings = get_test_settings()
+        with self.assertRaises(KeyError):
+            s = settings["key1"]
+        


### PR DESCRIPTION
As described in commit messages, I've made an attempt at replacing the hard-coded path to git command with several changes that allow the RawGit class to accept it as a parameter, possibly from a settings file, managed by a new settings.py module.

Added unit tests for the new settings.py module using Nose2.
Created a Nose2 version for all existing unit test modules as nose is in maintenance mode and may be discontinued according to: https://nose.readthedocs.io/en/latest/
all unit tests pass successfully.